### PR TITLE
->translate() $form plural fix

### DIFF
--- a/GettextTranslator/Gettext.php
+++ b/GettextTranslator/Gettext.php
@@ -148,6 +148,14 @@ class Gettext extends Nette\Object implements Nette\Localization\ITranslator
 
 		} elseif (is_numeric($form)) {
 			$form = (int) $form;
+			
+			if($form < 2) {
+				$message_plural = 0;
+			} elseif($form < 5) {
+				$message_plural = 1;
+			} else {
+				$message_plural = 2;
+			}
 
 		} elseif (!is_int($form) || $form === NULL) {
 			$form = 1;


### PR DESCRIPTION
If you handle numeric $form parameter to translate() function, the current version doesn't translate the message to plural form at all. This should fix it.
