### PR TITLE
fixed translation for plural translation with missing translation

### DIFF
--- a/GettextTranslator/Gettext.php
+++ b/GettextTranslator/Gettext.php
@@ -183,7 +183,7 @@ class Gettext extends Nette\Object implements Nette\Localization\ITranslator
 				$this->sessionStorage->newStrings[$this->lang][$message] = empty($message_plural) ? array($message) : array($message, $message_plural);
 			}
 
-			if ($form > 1 && !empty($message_plural)) {
+			if ($form > 1 && !empty($message_plural) && is_string($message_plural)) {
 				$message = $message_plural;
 			}
 		}


### PR DESCRIPTION
In case there is no translation, the current version return the code of plural version
